### PR TITLE
Fix race condition in task deploy

### DIFF
--- a/src/Taskfile.yaml
+++ b/src/Taskfile.yaml
@@ -177,15 +177,16 @@ tasks:
   deploy:
     desc: Install plugin package in Corporate Memory
     deps:
+      - build
     cmds:
-      - task: clean
-      - task: build
       - cmemc admin workspace python install dist/*.tar.gz
       - cmemc admin workspace python list-plugins
 
   build:
     desc: Build a tarball and a wheel package
     <<: *preparation
+    deps:
+      - clean
     cmds:
       - poetry build
 

--- a/src/Taskfile.yaml
+++ b/src/Taskfile.yaml
@@ -177,9 +177,9 @@ tasks:
   deploy:
     desc: Install plugin package in Corporate Memory
     deps:
-      - clean
-      - build
     cmds:
+      - task: clean
+      - task: build
       - cmemc admin workspace python install dist/*.tar.gz
       - cmemc admin workspace python list-plugins
 


### PR DESCRIPTION
Executing `task deploy` can end up in a race condition, that the `dist` folder is recursively deleted while it is recreated, which ends up in a failure as can be seen below:

```
$ task deploy
task: [clean] rm -rf dist .mypy_cache .pytest_cache
task: [check:prepare] mkdir -p dist/coverage
rm: cannot remove 'dist': Directory not empty
task: Failed to run task "clean": exit status 1

```