### PR TITLE
update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](https://semver.org/)
 
+## [Unreleased]
+
+### Changed
+
+- coverage report does some advanced exclusion:
+  - https://coverage.readthedocs.io/en/7.5.0/excluding.html#advanced-exclusion
+
+
 ## [6.1.0] 2024-02-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - coverage report does some advanced exclusion:
   - https://coverage.readthedocs.io/en/7.5.0/excluding.html#advanced-exclusion
 
+### Security
+
+- ignore pips 67599 safety issue
+
 
 ## [6.1.0] 2024-02-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Added
+
+- pytest-html report generation
+
 ### Changed
 
 - coverage report does some advanced exclusion:
   - https://coverage.readthedocs.io/en/7.5.0/excluding.html#advanced-exclusion
+- update dependencies
 
 ### Security
 

--- a/src/Taskfile.yaml
+++ b/src/Taskfile.yaml
@@ -144,8 +144,8 @@ tasks:
     <<: *preparation
     cmds:
       # ignore 51358 safety - dev dependency only
-      # ignore 61489 pillow - dev dependency only
-      - poetry run safety check -i 51358 -i 61489
+      # ignore 67599 pip - dev dependency only
+      - poetry run safety check -i 51358 -i 67599
 
   check:ruff:
     desc: Complain about everything else

--- a/src/Taskfile.yaml
+++ b/src/Taskfile.yaml
@@ -113,11 +113,13 @@ tasks:
           poetry run pytest --junitxml={{.JUNIT_FILE}}
           --cov-report term  --cov-report xml:{{.COVERAGE_FILE}}
           --cov-report html:{{.COVERAGE_DIR}} --cov={{.PACKAGE}}
+          --html={{.HTML_FILE}} --self-contained-html
       - platforms: [darwin, linux]
         cmd: >
           poetry run pytest --memray --junitxml={{.JUNIT_FILE}}
           --cov-report term --cov-report xml:{{.COVERAGE_FILE}}
           --cov-report html:{{.COVERAGE_DIR}} --cov={{.PACKAGE}}
+          --html={{.HTML_FILE}} --self-contained-html
       - cmd: >
           poetry run genbadge coverage -l
           -i {{.COVERAGE_FILE}} -o {{.BADGE_COVERAGE}}
@@ -125,11 +127,12 @@ tasks:
           poetry run genbadge tests -l
           -i {{.JUNIT_FILE}} -o {{.BADGE_TESTS}}
     vars:
-      JUNIT_FILE: ./{{.DIST_DIR}}/junit-pytest.xml
-      COVERAGE_FILE: ./{{.DIST_DIR}}/coverage.xml
-      COVERAGE_DIR: ./{{.DIST_DIR}}/coverage
       BADGE_COVERAGE: ./{{.DIST_DIR}}/badge-coverage.svg
       BADGE_TESTS: ./{{.DIST_DIR}}/badge-tests.svg
+      COVERAGE_DIR: ./{{.DIST_DIR}}/coverage
+      COVERAGE_FILE: ./{{.DIST_DIR}}/coverage.xml
+      HTML_FILE: ./{{.DIST_DIR}}/pytest.html
+      JUNIT_FILE: ./{{.DIST_DIR}}/junit-pytest.xml
 
   check:mypy:
     desc: Complain about typing errors

--- a/src/pyproject.toml.jinja
+++ b/src/pyproject.toml.jinja
@@ -20,18 +20,19 @@ keywords = [
 python = "^3.11"
 
 [tool.poetry.dependencies.cmem-plugin-base]
-version = "^4.3.0"
+version = "^4.5.0"
 allow-prereleases = false
 
 [tool.poetry.group.dev.dependencies]
 genbadge = {extras = ["coverage"], version = "^1.1.1"}
-mypy = "^1.2.0"
-pip = ">=23.3" # Avoid safety issue 62044 for pip less than 23.3
-pytest = "^7.3.1"
+mypy = "^1.10.0"
+pip = "^24"
+pytest = "^7.4.4"
 pytest-cov = "^4.1.0"
 pytest-dotenv = "^0.5.2"
-pytest-memray = { version = "^1.5.0",  markers = "platform_system != 'Windows'" }
-ruff = "^0.1.5"
+pytest-html = "^4.1.1"
+pytest-memray = { version = "^1.6.0",  markers = "platform_system != 'Windows'" }
+ruff = "^0.1.15"
 safety = "^1.10.3"
 
 [build-system]

--- a/src/pyproject.toml.jinja
+++ b/src/pyproject.toml.jinja
@@ -51,6 +51,18 @@ ignore_missing_imports = true
 [tool.pytest.ini_options]
 addopts = ""
 
+[tool.coverage.report]
+exclude_also = [
+    "def __repr__",
+    "if self.debug:",
+    "if settings.DEBUG",
+    "raise AssertionError",
+    "raise NotImplementedError",
+    "if TYPE_CHECKING:",
+    "class .*\\bProtocol\\):",
+    "@(abc\\.)?abstractmethod",
+    ]
+
 [tool.ruff]
 line-length = 100
 target-version = "py311"


### PR DESCRIPTION
### Added

- pytest-html report generation

### Changed

- coverage report does some advanced exclusion:
  - https://coverage.readthedocs.io/en/7.5.0/excluding.html#advanced-exclusion
- update dependencies

### Security

- ignore pips 67599 safety issue